### PR TITLE
SPI divisor is even, not power of 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -749,7 +749,7 @@ polarity.
 rpio.spiSetCSPolarity(0, rpio.HIGH);    /* Set CE0 high to activate */
 ```
 
-Set the SPI clock speed with `spiSetClockDivider()`.  This is a power-of-two
+Set the SPI clock speed with `spiSetClockDivider()`.  This is an even
 divisor of the base 250MHz rate, defaulting to `0 == 65536 == 3.81kHz`.
 
 ```js

--- a/lib/rpio.js
+++ b/lib/rpio.js
@@ -626,7 +626,8 @@ rpio.prototype.spiSetCSPolarity = function(cs, active)
 rpio.prototype.spiSetClockDivider = function(divider)
 {
 	if (divider !== 0 && (divider & (divider - 1)) !== 0)
-		throw "Clock divider must be zero or power of two";
+//		throw "Clock divider must be zero or power of two"; //not true according to http://raspberrypi.stackexchange.com/questions/699/what-spi-frequencies-does-raspberry-pi-support
+		console.log( "warning: SPI Clock divider is not a power of two: " + divider);
 
 	return binding.spi_set_clock_divider(divider);
 }


### PR DESCRIPTION
I needed an SPI divisor of 104 to drive some WS281X RGB pixels (needs a clock of 2.4 MHz to conform to WS281X NRZ timing specs), so I relaxed the restriction in rpio.js.  For more info, see:
http://raspberrypi.stackexchange.com/questions/699/what-spi-frequencies-does-raspberry-pi-support