### PR TITLE
PWM Pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,7 +625,7 @@ low at particular times), but you are limited to only certain pins supporting
 hardware PWM:
 
 * 26-pin models: pin 12
-* 40-pin models: pins 12, 19, 33, 35
+* 40-pin models: pins 12, 32, 33, 35
 
 Hardware PWM also requires `gpiomem: false` and root privileges.  `.open()`
 will call `.init()` with the appropriate values if you do not explicitly call


### PR DESCRIPTION
Tested on my RPi 3
PWM pins is: 12, 32, 33, 35

With this code:

```
var rpio = require('rpio')
rpio.init({gpiomem: false, mapping: 'physical'})

let count = 0
let pins = [];

for (let pin = 1; pin <= 40; pin++) {
    let valid = true
    try {
        //console.log("pin: " + pin)
        rpio.open(pin, rpio.PWM)
        rpio.close(pin)
    } catch (err) {
        //console.log("error: " + pin)
        valid = false
    }

    if (valid) {
        ++count
        pins.push(pin)
    }
}
console.log("#################")
console.log("Total PWM pins: " + count)
console.log("Pins: ")
pins.forEach(function(pin, i, arr) {
    console.log(pin)
})
console.log("#################")
```

got output:

```
pi@raspberrypi:~/test/blink $ sudo node pwm_test.js
#################
Total PWM pins: 4
Pins:
12
32
33
35
#################
```
