### PR TITLE
Add mode option to close method

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,17 +464,24 @@ rpio.poll(11, regular_button);
 rpio.poll(12, nuke_button, rpio.POLL_HIGH);
 ```
 
-#### `rpio.close(pin)`
+#### `rpio.close(pin[, reset])`
 
-Reset `pin` to `rpio.INPUT` and clear any pullup/pulldown resistors and poll
-events.
+Indicate that the pin will no longer be used, and clear any poll events
+associated with it.
+
+The optional `reset` argument can be used to configure the state that `pin`
+will be left in after close:
+
+* `rpio.PIN_RESET`: return pin to `rpio.INPUT` and clear any pullup/pulldown
+  resistors.  This is the default.
+* `rpio.PIN_PRESERVE`: leave pin in its currently configured state.
 
 Examples:
 
 ```js
 rpio.close(11);
-rpio.close(12);
-rpio.close(13);
+rpio.close(12, rpio.PIN_RESET);
+rpio.close(13, rpio.PIN_PRESERVE);
 ```
 
 #### GPIO demo

--- a/lib/rpio.js
+++ b/lib/rpio.js
@@ -57,6 +57,12 @@ rpio.prototype.POLL_HIGH = 0x2;	/* Rising edge detect */
 rpio.prototype.POLL_BOTH = 0x3;	/* POLL_LOW | POLL_HIGH */
 
 /*
+ * Reset pin status on close (default), or preserve current status.
+ */
+rpio.prototype.PIN_PRESERVE = 0x0;
+rpio.prototype.PIN_RESET = 0x1;
+
+/*
  * Pin event polling.  We track which pins are being monitored, and create a
  * bitmask for efficient checks.  The event_poll function is executed in a
  * setInterval() context whenever any pins are being monitored, and emits
@@ -500,17 +506,21 @@ rpio.prototype.poll = function(pin, cb, direction)
 	}
 }
 
-rpio.prototype.close = function(pin)
+rpio.prototype.close = function(pin, reset)
 {
 	var gpiopin = pin_to_gpio(pin);
 
-	if (!rpio_options.gpiomem)
-		rpio.prototype.pud(pin, rpio.prototype.PULL_OFF);
-
-	rpio.prototype.mode(pin, rpio.prototype.INPUT);
+	if (reset === undefined)
+		reset = rpio.prototype.PIN_RESET;
 
 	if (gpiopin in event_pins)
 		rpio.prototype.poll(pin, null);
+
+	if (reset) {
+		if (!rpio_options.gpiomem)
+			rpio.prototype.pud(pin, rpio.prototype.PULL_OFF);
+		rpio.prototype.mode(pin, rpio.prototype.INPUT);
+	}
 }
 
 /*


### PR DESCRIPTION
## Overview
Add `mode` option to `rpio.close()` method to prevent GPIO defaulting to INPUT on `close()`

I would like to keep a particular GPIO pin as an output after closing the pin, and it was not possible with the current method because it always set it to an INPUT when closing. This change would allow the user to explicitly define the closing mode through the optional `mode` parameter.

## Problem
Here we write a particular output to LOW and then close. I would like the output to stay LOW after closing. In the current method, the GPIO would be set to INPUT and the output would not stay LOW, but rather go LOW momentarily, and then go HIGH.
```
rpio.open(pinNumber, rpio.OUTPUT, rpio.HIGH);
rpio.write(pinNumber, rpio.LOW);
rpio.close(pinNumber);
```

## Solution
Instead of assuming that the GPIO should be set to an INPUT when closing, allow the user to specify what the ending mode should be. In the example below, one can explicitly define the closing mode.
```
rpio.open(pinNumber, rpio.OUTPUT, rpio.LOW);
rpio.write(pinNumber, rpio.HIGH);
rpio.close(pinNumber, rpio.OUTPUT);
```