### PR TITLE
Fix removing for listeners to new event handler

### DIFF
--- a/lib/rpio.js
+++ b/lib/rpio.js
@@ -593,7 +593,7 @@ rpio.prototype.poll = function(pin, cb, direction)
 
 		bindcall(binding.gpio_event_clear, gpiopin);
 
-		rpio.prototype.removeListener('pin' + gpiopin, event_pins[gpiopin]);
+		module.exports.removeListener('pin' + gpiopin, event_pins[gpiopin]);
 
 		delete event_pins[gpiopin];
 		event_mask &= ~(1 << gpiopin);


### PR DESCRIPTION
In commit 0e5886ad71d4cc58b935d86eedf62c2e4325cb4e a new event listener was introduced - where the poll function was not properly updated to remove active poll listeners.

Should fix #56