### PR TITLE
Add Revision code for Raspberry Pi 3 Model A+

### DIFF
--- a/lib/rpio.js
+++ b/lib/rpio.js
@@ -283,6 +283,7 @@ function detect_pinmap()
 	case 0x2082:
 	case 0x20a0: // Compute Module 3, needs separate pinmap?
 	case 0x20d3:
+	case 0x20e0: // Raspberry Pi 3 Model A+ 
 		pinmap = 'PINMAP_40';
 		break;
 	default:


### PR DESCRIPTION
Model A+ needs to be recognised as board revision 0x20e0