### PR TITLE
Change direction in call to rpio.poll in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ function pollcb(pin)
         console.log('Button pressed on pin P%d', pin);
 }
 
-rpio.poll(15, pollcb, rpio.POLL_DOWN);
+rpio.poll(15, pollcb, rpio.POLL_LOW);
 ```
 
 A collection of example programs are also available in the


### PR DESCRIPTION
Changed the direction argument for rpio.poll in the polling example from POLL_DOWN to POLL_LOW.

Noticed the example call didn't match the API documentation.