### PR TITLE
Option to prevent automatic close of rpio

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ var options = {
         gpiomem: true,          /* Use /dev/gpiomem */
         mapping: 'physical',    /* Use the P1-P40 numbering scheme */
         mock: undefined,        /* Emulate specific hardware in mock mode */
+        close_on_exit: true,    /* On node process exit automatically close rpio */
 }
 ```
 
@@ -319,6 +320,40 @@ rpio.init({mock: 'raspi-3'});
 
 /* Override default warn handler to avoid mock warnings */
 rpio.on('warn', function() {});
+```
+
+##### `close_on_exit`
+
+Rpio automatically cleans up and closes all pins when the node process exits. If
+you need to hook exit yourself and do cleanup with rpio set `close_on_exit: false`
+to allow you to perform any cleanup. Make sure you call `rpio.exit()` in your exit
+hook.
+
+Example:
+
+```js
+rpio.init({close_on_exit: false});    
+
+process.on('exit', () => {
+  /* Any custom cleanup using rpio */      
+  rpio.exit();
+});
+```
+
+#### `rpio.exit()`
+
+Shuts down the rpio library.  By default this will happen automatically. This method
+is provided to allow manual shutdown when using `close_on_exit: false`.
+
+Example:
+
+```js
+rpio.init({close_on_exit: false});    
+
+process.on('exit', () => {
+  /* Any custom cleanup using rpio */      
+  rpio.exit();
+});
 ```
 
 #### `rpio.open(pin, mode[, option])`

--- a/lib/rpio.js
+++ b/lib/rpio.js
@@ -88,6 +88,7 @@ var rpio_options = {
 	gpiomem: true,
 	mapping: 'physical',
 	mock: false,
+	close_on_exit: true
 };
 
 /* Default mock mode if hardware is unsupported. */
@@ -454,6 +455,15 @@ rpio.prototype.init = function(opts)
 		}
 	}
 
+	/* 
+	 * Allow the user to suppress automatic close of rpio on exit
+	 */
+	if (rpio_options.close_on_exit) {
+		process.on('exit', function(code) {
+			rpio.prototype.exit();
+		});
+	}
+
 	/*
 	 * Open the bcm2835 driver.
 	 */
@@ -626,6 +636,11 @@ rpio.prototype.close = function(pin, reset)
 			rpio.prototype.pud(pin, rpio.prototype.PULL_OFF);
 		rpio.prototype.mode(pin, rpio.prototype.INPUT);
 	}
+}
+
+rpio.prototype.exit = function()
+{
+	bindcall(binding.rpio_close);
 }
 
 /*
@@ -816,6 +831,3 @@ rpio.prototype.usleep = function(usecs)
 	bindcall(binding.rpio_usleep, usecs);
 }
 
-process.on('exit', function(code) {
-	bindcall(binding.rpio_close);
-});


### PR DESCRIPTION
I have a case where I need to do cleanup of various rpio pins prior to shutting down rpio.

* Adds a new option to prevent automatic close_on_exit.  Maintains previous behavior by defaulting to true
* Adds a new prototype method. exit, to shut down rpio
* Updates docs

Addresses #118 