### PR TITLE
Plus board pinmap detection

### DIFF
--- a/lib/rpio.js
+++ b/lib/rpio.js
@@ -270,7 +270,7 @@ function detect_pinmap()
 		/*
 		 * Regular 26-pin variants with the P5 header.
 		 */
-		if (m[1].lastIndexOf('Model', 0) == 0) {
+		if ((m[1].lastIndexOf('Model', 0) == 0) && (m[1].indexOf("Plus") === -1)) {
 			pinmap = 'PINMAP_26';
 			return true;
 		}


### PR DESCRIPTION
During testing on different boards I found out that my B+ board was not detected properly. This solves the 40 pin "Plus" board detection