### PR TITLE
Added proper pinmap detection for BPI-M2P Zero 40pin

### DIFF
--- a/lib/rpio.js
+++ b/lib/rpio.js
@@ -590,9 +590,21 @@ function detect_pinmap()
 	}
 
 	/*
+	 * Banana Pi M2 Zero (H2+)
+	 * Banana Pi M2P Zero (H2+) (40 pin)
+	 */
+	if ((m = model.match(/^sun8iw7p1/)) ||
+			(m = model.match(/Banana Pi BPI-M2-Zero/))) {
+		soctype = rpio.prototype.SOC_SUNXI;
+		pinmap = 'PINMAP_BPI_M2Z';
+		return true;
+	}
+	/*
 	 * Orange Pi Zero (H2+)
 	 *
 	 * XXX: According to linux-sunxi.org sun8iw7p may match 40-pin models?
+	 * Zw1d: And it does. That's why BPI-M2-Zero definition was moved above
+	 * and sun8iw7p1 was added.
 	 */
 	if ((m = model.match(/^sun8iw7p/)) ||
 	    (m = model.match(/Orange Pi Zero/))) {
@@ -600,16 +612,6 @@ function detect_pinmap()
 		pinmap = 'PINMAP_OPI_26';
 		return true;
 	}
-
-	/*
-	 * Banana Pi M2 Zero (H2+)
-	 */
-	if (m = model.match(/Banana Pi BPI-M2-Zero/)) {
-		soctype = rpio.prototype.SOC_SUNXI;
-		pinmap = 'PINMAP_BPI_M2Z';
-		return true;
-	}
-
 	/*
 	 * Banana Pi M2 Ultra (R40, V40)
 	 */


### PR DESCRIPTION
BPI-M2P Zero (with the P) was being matched incorrectly with 26-pin pinmaps, while it has 40 pins. 