### PR TITLE
feat: adding support for device_tree_path in rpio.init to fix #154 ra…

### DIFF
--- a/lib/rpio.js
+++ b/lib/rpio.js
@@ -94,7 +94,8 @@ var rpio_options = {
 	gpiomem: true,
 	mapping: 'physical',
 	mock: false,
-	close_on_exit: true
+	close_on_exit: true,
+	device_tree_path: '/proc/device-tree/model',
 };
 
 /* Default mock mode if hardware is unsupported. */
@@ -539,7 +540,7 @@ function detect_pinmap()
 	var model;
 
 	try {
-		model = fs.readFileSync('/proc/device-tree/model', 'ascii');
+		model = fs.readFileSync(rpio_options.device_tree_path, 'ascii');
 		model = model.replace(/\0+$/, '');
 	} catch (err) {
 		return false;


### PR DESCRIPTION
Fix for #154 
feat: adding support for device_tree_path in rpio.init to fix #154 rather than assume /proc/device-tree/model
This allows non privileged docker containers to specify a different path for the model file since it can't use /proc/device-tree/model