### PR TITLE
Update min version of nan dependency to 2.18.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,12 @@ matrix:
     #- name: 'Ubuntu - Node.js 15'
     #  os: linux
     #  node_js: "15"
+    - name: 'Ubuntu - Node.js 18'
+      os: linux
+      node_js: "18"
+    - name: 'Ubuntu - Node.js 16'
+      os: linux
+      node_js: "16"
     - name: 'Ubuntu - Node.js 14'
       os: linux
       node_js: "14"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ as i²c, PWM, and SPI.
 
 * Raspberry Pi Models: A, B, A+, B+, 2, 3, 4, 400, Compute Module, Zero.
 * SunXi (Allwinner V40) Models: Orange Pi Zero, Banana Pi M2 Zero / Berry.
-* Node.js Versions: 0.8, 0.10, 0.12, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14.
+* Node.js Versions: 0.8, 0.10, 0.12, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 18, 20.
 
 Currently only basic GPIO is supported on the SunXi chipsets.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2241,9 +2241,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
+      "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w=="
     },
     "natural-compare": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "bindings": "~1.5.0",
-    "nan": "^2.14.1"
+    "nan": "^2.18.0"
   },
   "devDependencies": {
     "eslint": "~6.5.0",


### PR DESCRIPTION
## Description

Update nan dependency to 2.18.0 (latest). Version 2.17.0 is the minimum required to overcome the `AccessorSignatures` issue when using Node 20. Dependencies added with Node 14 to keep old version of package.lock.json.

Added CI config for Node 16/18 as by now LTS is probably using version 20 and don't want any regressions with previous versions.

Updated documentation with versions of node supported as I have verified and used this library with these versions.